### PR TITLE
Add skeleton Lotus IRM simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -r requirements.txt
+      - run: pytest --cov=lotus

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# lotus-research
+![CI](https://github.com/example/lotus-research/actions/workflows/ci.yml/badge.svg)
+# Lotus IRM Simulation
 
-This repository collects experiments around the Lotus interest-rate model.
+This package provides a toy implementation of the Lotus interest rate model.
 
-## Simulations
+## Setup
 
-
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/lotus/__init__.py
+++ b/lotus/__init__.py
@@ -1,0 +1,2 @@
+from .core import LotusState, apply_action
+\n__all__ = ['LotusState', 'apply_action']

--- a/lotus/adaptive.py
+++ b/lotus/adaptive.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+from math import exp
+
+getcontext().prec = 28
+
+KAPPA_P = Decimal('50') / Decimal('31536000')  # approx seconds per year
+TARGET_UTIL = Decimal('0.9')
+R_MIN = Decimal('0.001')
+R_MAX = Decimal('2.0')
+
+
+def adapt_rate(
+    current_rate: Decimal,
+    util: Decimal,
+    delta_t: Decimal,
+) -> Decimal:
+    """Adjust target rate toward utilisation."""
+    if util > TARGET_UTIL:
+        e = (util - TARGET_UTIL) / (Decimal(1) - TARGET_UTIL)
+    else:
+        e = (util - TARGET_UTIL) / TARGET_UTIL
+    speed = Decimal(exp(float(KAPPA_P * e * delta_t)))
+    new_rate = current_rate * speed
+    return max(R_MIN, min(R_MAX, new_rate))

--- a/lotus/core.py
+++ b/lotus/core.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal, getcontext
+from typing import Dict, List, Optional
+
+# Use high precision for rates
+getcontext().prec = 28
+
+Tick = int
+
+@dataclass
+class LotusState:
+    """Represents the state of the Lotus IRM."""
+
+    ticks: int = 101
+    supply: List[Decimal] = field(default_factory=lambda: [Decimal(0)] * 101)
+    borrow: List[Decimal] = field(default_factory=lambda: [Decimal(0)] * 101)
+    target_rate: List[Decimal] = field(
+        default_factory=lambda: [Decimal("0.001")] * 101
+    )
+    last_time: int = 0
+
+
+def apply_action(state: LotusState, action: Dict[str, Decimal | int]) -> LotusState:
+    """Apply an action and return updated state."""
+
+    new_state = LotusState(
+        ticks=state.ticks,
+        supply=list(state.supply),
+        borrow=list(state.borrow),
+        target_rate=list(state.target_rate),
+        last_time=action.get("t", state.last_time),
+    )
+
+    tick: Tick = int(action["tick"]) if "tick" in action else 0
+    amount: Decimal = Decimal(action.get("amount", 0))
+    act = action.get("action")
+
+    if act == "supply":
+        new_state.supply[tick] += amount
+    elif act == "borrow":
+        new_state.borrow[tick] += amount
+    elif act == "repay":
+        new_state.borrow[tick] = max(Decimal(0), new_state.borrow[tick] - amount)
+    elif act == "withdraw":
+        new_state.supply[tick] = max(Decimal(0), new_state.supply[tick] - amount)
+    else:
+        raise ValueError(f"unknown action {act}")
+
+    assert_invariants(new_state)
+    return new_state
+
+
+def assert_invariants(state: LotusState) -> None:
+    """Check IRM invariants."""
+
+    for s, b in zip(state.supply, state.borrow):
+        assert s >= 0
+        assert b >= 0
+
+    # additional invariants from specification would be added here
+

--- a/lotus/curve.py
+++ b/lotus/curve.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import List
+
+TARGET_UTIL = Decimal('0.9')
+
+
+def short_term_rate(util: Decimal, prev_rate: Decimal, next_rate: Decimal, prev_prev_rate: Decimal) -> Decimal:
+    """Compute borrow rate based on utilisation and neighboring target rates."""
+    if util > TARGET_UTIL:
+        return (next_rate - prev_rate) * (util - TARGET_UTIL) / (Decimal(1) - TARGET_UTIL) + prev_rate
+    return (prev_rate - prev_prev_rate) * (util - TARGET_UTIL) / TARGET_UTIL + prev_rate

--- a/lotus/invariants.py
+++ b/lotus/invariants.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .core import LotusState
+
+EPS = Decimal('1e-18')
+R_MIN = Decimal('0.001')
+R_MAX = Decimal('2.0')
+
+
+def assert_invariants(state: LotusState) -> None:
+    for s, b in zip(state.supply, state.borrow):
+        assert s >= 0
+        assert b >= 0
+
+    for i in range(state.ticks - 1):
+        assert state.target_rate[i] + EPS <= state.target_rate[i + 1]
+        assert R_MIN <= state.target_rate[i] <= R_MAX

--- a/lotus/scenarios.py
+++ b/lotus/scenarios.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, Iterable, List
+
+from .core import LotusState, apply_action
+
+
+def run_scenario(initial: LotusState, actions: Iterable[Dict]) -> List[LotusState]:
+    states = [initial]
+    state = initial
+    for act in actions:
+        state = apply_action(state, act)
+        states.append(state)
+    return states

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 79
+
+[tool.isort]
+profile = "black"
+
+[tool.flake8]
+max-line-length = 79
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+pandas
+matplotlib
+scipy
+pytest
+hypothesis
+pytest-cov

--- a/scripts/run_scenario.py
+++ b/scripts/run_scenario.py
@@ -1,0 +1,17 @@
+import json
+import sys
+from pathlib import Path
+
+from lotus.core import LotusState, apply_action
+from lotus.scenarios import run_scenario
+
+
+def main(path: str) -> None:
+    actions = json.loads(Path(path).read_text())
+    states = run_scenario(LotusState(), actions)
+    for i, s in enumerate(states):
+        print(i, sum(s.supply), sum(s.borrow))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/tests/property/test_invariants.py
+++ b/tests/property/test_invariants.py
@@ -1,0 +1,21 @@
+from hypothesis import given, strategies as st
+from lotus.core import LotusState, apply_action
+
+
+action_strategy = st.fixed_dictionaries(
+    {
+        "action": st.sampled_from(["supply", "borrow", "repay", "withdraw"]),
+        "tick": st.integers(min_value=0, max_value=100),
+        "amount": st.integers(min_value=0, max_value=1000),
+    }
+)
+
+
+@given(st.lists(action_strategy, min_size=1, max_size=50))
+def test_no_negative(actions):
+    state = LotusState()
+    for act in actions:
+        state = apply_action(state, act)
+
+    assert all(s >= 0 for s in state.supply)
+    assert all(b >= 0 for b in state.borrow)

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+
+import pytest
+
+from lotus.core import LotusState, apply_action
+
+
+def make_action(action: str, tick: int, amount: int):
+    return {"action": action, "tick": tick, "amount": amount}
+
+
+def run_sequence(n: int) -> LotusState:
+    state = LotusState()
+    for i in range(n):
+        state = apply_action(state, make_action("supply", i % state.ticks, i))
+    return state
+
+
+# Generate 30 deterministic tests using parametrization
+@pytest.mark.parametrize("n", range(1, 31))
+def test_sequences(n):
+    state = run_sequence(n)
+    assert sum(state.supply) == sum(range(n))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+
+from lotus.core import LotusState, apply_action
+
+
+def make_action(action: str, tick: int, amount: int):
+    return {"action": action, "tick": tick, "amount": amount}
+
+
+# generate simple deterministic tests
+def test_sequence():
+    state = LotusState()
+    actions = [make_action("supply", i % state.ticks, 100) for i in range(10)]
+    for act in actions:
+        state = apply_action(state, act)
+
+    assert sum(state.supply) == Decimal(1000)
+
+
+def test_30_cases():
+    state = LotusState()
+    for i in range(30):
+        state = apply_action(state, make_action("supply", i % state.ticks, i))
+    assert len(state.supply) == state.ticks


### PR DESCRIPTION
## Summary
- add Lotus IRM python package with core state and basic invariants
- stub out curve and adaptive rate logic
- provide scenario runner and simple CI workflow
- include deterministic and property-based tests

## Testing
- `pytest -q` *(fails: pytest not installed)*